### PR TITLE
Feature: QoE Metrics Reporting

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,6 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="Embedded JDK" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.7.20" />
+  </component>
+</project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.7.20" />
+    <option name="version" value="1.9.0" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="JavadocGenerationManager">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="JavadocGenerationManager">
+    <option name="OUTPUT_DIRECTORY" value="$PROJECT_DIR$/jsdoc" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,6 @@ android {
 }
 
 dependencies {
-
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.8.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdk 29
         targetSdk 33
         versionCode 1
-        versionName "1.0.0"
+        versionName "1.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
     // 5GMAG
-    implementation 'com.fivegmag:a5gmscommonlibrary:1.0.1'
+    implementation 'com.fivegmag:a5gmscommonlibrary:1.1.0'
 
     // Retrofit
     def retrofit_version = "2.9.0"

--- a/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/MainActivity.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/MainActivity.kt
@@ -13,8 +13,14 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 
 class MainActivity : AppCompatActivity() {
+
+    /**
+     *  Entry point of the application
+     * @param savedInstanceState
+     */
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
     }
+
 }

--- a/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/MediaSessionHandlerMessengerService.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/MediaSessionHandlerMessengerService.kt
@@ -69,6 +69,9 @@ class MediaSessionHandlerMessengerService() : Service() {
                 SessionHandlerMessageTypes.REPORT_PLAYBACK_METRICS_CAPABILITIES -> handlePlaybackMetricsCapabilitiesMessage(
                     msg
                 )
+                SessionHandlerMessageTypes.REPORT_PLAYBACK_METRICS -> handlePlaybackMetricsMessage(
+                    msg
+                )
 
                 else -> super.handleMessage(msg)
             }
@@ -206,6 +209,18 @@ class MediaSessionHandlerMessengerService() : Service() {
 
             //TODO: For unsupported schemes: An error message shall be sent by the Media Session Handler to the appropriate network entity, indicating that metrics reporting for the indicated metrics scheme cannot be supported for this streaming service
 
+        }
+
+        private fun handlePlaybackMetricsMessage(msg: Message) {
+            val bundle: Bundle = msg.data
+            val metrics: String? = bundle.getString("qoeMetricsReport")
+            val sendingUid = msg.sendingUid
+
+            Toast.makeText(
+                applicationContext,
+                "Media Session Handler Service received metrics message",
+                Toast.LENGTH_SHORT
+            ).show()
         }
 
         /**

--- a/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/MediaSessionHandlerMessengerService.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/MediaSessionHandlerMessengerService.kt
@@ -84,7 +84,7 @@ class MediaSessionHandlerMessengerService() : Service() {
 
         private fun handleStatusMessage(msg: Message) {
             val bundle: Bundle = msg.data as Bundle
-            val sendingUid = msg.sendingUid;
+            val sendingUid = msg.sendingUid
             val state: String = bundle.getString("playbackState", "")
             Toast.makeText(
                 applicationContext,
@@ -162,7 +162,7 @@ class MediaSessionHandlerMessengerService() : Service() {
             bundle.classLoader = SchemeSupport::class.java.classLoader
             val schemeSupport: ArrayList<SchemeSupport>? =
                 bundle.getParcelableArrayList("schemeSupport")
-            val sendingUid = msg.sendingUid;
+            val sendingUid = msg.sendingUid
             val clientMetricsReportingConfigurations: ArrayList<ClientMetricsReportingConfiguration>? =
                 clientsSessionData[sendingUid]?.serviceAccessInformation?.clientMetricsReportingConfigurations
 
@@ -241,7 +241,7 @@ class MediaSessionHandlerMessengerService() : Service() {
             val messenger = clientsSessionData[clientId]?.messenger
             bundle.putStringArrayList("metricsSchemes", metricsSchemes)
             msg.data = bundle
-            msg.replyTo = mMessenger;
+            msg.replyTo = mMessenger
             try {
                 messenger?.send(msg)
             } catch (e: RemoteException) {

--- a/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/MediaSessionHandlerMessengerService.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/MediaSessionHandlerMessengerService.kt
@@ -215,12 +215,6 @@ class MediaSessionHandlerMessengerService() : Service() {
             val bundle: Bundle = msg.data
             val metrics: String? = bundle.getString("qoeMetricsReport")
             val sendingUid = msg.sendingUid
-
-            Toast.makeText(
-                applicationContext,
-                "Media Session Handler Service received metrics message",
-                Toast.LENGTH_SHORT
-            ).show()
         }
 
         /**

--- a/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/MediaSessionHandlerMessengerService.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/MediaSessionHandlerMessengerService.kt
@@ -309,8 +309,10 @@ class MediaSessionHandlerMessengerService() : Service() {
                         )
                         clientsSessionData[clientId]?.metricReportingTimer?.add(timer)
                         // Select one of the servers to report the metrics to
-                        val serverAddress =
+                        var serverAddress =
                             clientMetricsReportingConfiguration.serverAddresses.random()
+                        // Add a "/" in the end if not present
+                        serverAddress = utils.addTrailingSlashIfNeeded(serverAddress)
                         val retrofit = retrofitBuilder.baseUrl(serverAddress).build()
                         clientsSessionData[clientId]?.metricsReportingApi =
                             retrofit.create(MetricsReportingApi::class.java)

--- a/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/models/ClientSessionModel.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/models/ClientSessionModel.kt
@@ -2,6 +2,7 @@ package com.fivegmag.a5gmsmediasessionhandler.models
 
 import android.os.Messenger
 import com.fivegmag.a5gmscommonlibrary.models.ServiceAccessInformation
+import com.fivegmag.a5gmsmediasessionhandler.network.MetricsReportingApi
 import com.fivegmag.a5gmsmediasessionhandler.network.ServiceAccessInformationApi
 import java.util.*
 import kotlin.collections.HashMap
@@ -10,5 +11,6 @@ data class ClientSessionModel(
     var messenger: Messenger?,
     var serviceAccessInformation: ServiceAccessInformation? = null,
     var metricReportingTimer: LinkedList<Timer> = LinkedList(),
-    var serviceAccessInformationApi: ServiceAccessInformationApi? = null
+    var serviceAccessInformationApi: ServiceAccessInformationApi? = null,
+    var metricsReportingApi: MetricsReportingApi? = null
 )

--- a/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/models/ClientSessionModel.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/models/ClientSessionModel.kt
@@ -2,11 +2,13 @@ package com.fivegmag.a5gmsmediasessionhandler.models
 
 import android.os.Messenger
 import com.fivegmag.a5gmscommonlibrary.models.ServiceAccessInformation
+import com.fivegmag.a5gmsmediasessionhandler.network.ServiceAccessInformationApi
 import java.util.*
 import kotlin.collections.HashMap
 
 data class ClientSessionModel(
     var messenger: Messenger?,
-    var serviceAccessInformation: ServiceAccessInformation?,
-    var metricReportingTimer: LinkedList<Timer>
+    var serviceAccessInformation: ServiceAccessInformation? = null,
+    var metricReportingTimer: LinkedList<Timer> = LinkedList(),
+    var serviceAccessInformationApi: ServiceAccessInformationApi? = null
 )

--- a/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/models/ClientSessionModel.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/models/ClientSessionModel.kt
@@ -1,0 +1,12 @@
+package com.fivegmag.a5gmsmediasessionhandler.models
+
+import android.os.Messenger
+import com.fivegmag.a5gmscommonlibrary.models.ServiceAccessInformation
+import java.util.*
+import kotlin.collections.HashMap
+
+data class ClientSessionModel(
+    var messenger: Messenger?,
+    var serviceAccessInformation: ServiceAccessInformation?,
+    var metricReportingTimer: LinkedList<Timer>
+)

--- a/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/network/MetricsReportingApi.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/network/MetricsReportingApi.kt
@@ -1,0 +1,22 @@
+package com.fivegmag.a5gmsmediasessionhandler.network
+
+import com.fivegmag.a5gmscommonlibrary.models.ServiceAccessInformation
+import okhttp3.RequestBody
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+
+interface MetricsReportingApi {
+
+    @POST("metrics-reporting/{provisioningSessionId}/{metricsReportingConfigurationId}")
+    fun sendMetricsReport(
+        @Path("provisioningSessionId") provisioningSessionId: String?,
+        @Path("metricsReportingConfigurationId") metricsReportingConfigurationId: String?,
+        @Body requestBody: RequestBody?
+    ): Call<Void>?
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.1' apply false
-    id 'com.android.library' version '7.3.1' apply false
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,5 +2,5 @@
 plugins {
     id 'com.android.application' version '7.4.2' apply false
     id 'com.android.library' version '7.4.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.0' apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Mar 06 16:36:08 CET 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
* Updates version number to 1.1.0
* Add support to query supported metrics reporting schemes from the Media Stream Handler
* Start a request timer for each of the supported metrics after receiving a READY event from the Exoplayer according to `reportingInterval`
* Decide whether to start the request timer based on `samplePercentage`
* Fetch metrics from the Media Stream Handler when the request timer has elapsed
* Send metrics report to a randomly selected address from `serverAddresses`
