### PR TITLE
Handle changes to the samplePercentage for consumption reporting

### DIFF
--- a/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/MediaSessionHandlerMessengerService.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/MediaSessionHandlerMessengerService.kt
@@ -318,6 +318,14 @@ class MediaSessionHandlerMessengerService() : Service() {
                 startConsumptionReportingTimer(clientId)
             }
 
+            // if sample percentage was previously zero and is now higher than zero evaluate again
+            if (updatedClientConsumptionReportingConfiguration.samplePercentage!! > 0 && previousClientConsumptionReportingConfiguration.samplePercentage <= 0 && shouldReportAccordingToSamplePercentage(
+                    updatedClientConsumptionReportingConfiguration.samplePercentage
+                )
+            ) {
+                startConsumptionReportingTimer(clientId)
+            }
+
             // updates of the reporting interval are handled automatically when stopping / starting the timer
         }
     }


### PR DESCRIPTION
If the samplePercentage is increased from zero to a value larger than zero we re-evaluate if consumption reporting should be started.

Addresses https://github.com/5G-MAG/rt-5gms-media-session-handler/issues/43#issuecomment-1825663508