### PR TITLE
Set the right content-type header for consumption reports and add han…

### DIFF
--- a/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/MediaSessionHandlerMessengerService.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/MediaSessionHandlerMessengerService.kt
@@ -570,7 +570,13 @@ class MediaSessionHandlerMessengerService() : Service() {
 
             call?.enqueue(object : retrofit2.Callback<Void?> {
                 override fun onResponse(call: Call<Void?>, response: Response<Void?>) {
-                    Log.d(TAG, "Successfully send consumption report")
+                    when(val responseCode = response.code()) {
+                        204 -> Log.d(TAG, "Consumption Report: Accepted")
+                        400 -> Log.d(TAG, "Consumption Report: Bad Request")
+                        415 -> Log.d(TAG, "Consumption Report: Unsupported Media Type")
+                        else -> Log.d(TAG, "Consumption Report: Return code $responseCode")
+                    }
+
                 }
 
                 override fun onFailure(call: Call<Void?>, t: Throwable) {

--- a/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/network/ConsumptionReportingApi.kt
+++ b/app/src/main/java/com/fivegmag/a5gmsmediasessionhandler/network/ConsumptionReportingApi.kt
@@ -12,10 +12,12 @@ package com.fivegmag.a5gmsmediasessionhandler.network
 import okhttp3.RequestBody
 import retrofit2.Call
 import retrofit2.http.Body
+import retrofit2.http.Headers
 import retrofit2.http.Path
 import retrofit2.http.POST
 
 interface ConsumptionReportingApi {
+    @Headers("Content-Type: application/json")
     @POST("consumption-reporting/{provisioningSessionId}")
     fun sendConsumptionReport(
         @Path("provisioningSessionId") provisioningSessionId: String?,


### PR DESCRIPTION
…dling for the different response codes of the AF.

This PR fixes #52 