### PR TITLE
Fix fatal exception due to UI element

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.5GMSMediaSessionHandler" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.5GMSMediaSessionHandler" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/fivegmag_blue</item>
         <item name="colorPrimaryVariant">@color/fivegmag_blue2</item>


### PR DESCRIPTION
Running the app on a phone with dark theme caused fatal exception due to action bar. 

```shell
FATAL EXCEPTION: main
Process: com.fivegmag.a5gmsmediasessionhandler, PID: 32383
java.lang.RuntimeException: Unable to start activity
Caused by: java.lang.IllegalStateException: This Activity already has an action bar supplied by the window decor. Do not
request Window.FEATURE_SUPPORT_ACTION_BAR and set windowActionBar to false in your theme to use a Toolbar
instead at androidx.appcompat.app.AppCompatDelegateImpl.setSupportActionBar(AppCompatDelegateImpl.java:606
``` 
This fixes it by using the DAYNIGHT theme with no action bar similar to LIGHT theme.